### PR TITLE
Fixed namespace issue due to roxygenise call

### DIFF
--- a/R/docstring.R
+++ b/R/docstring.R
@@ -139,7 +139,7 @@ docstring <- function(fun, fun_name = as.character(substitute(fun)),
     # roxygen uses cat to display the "Writing your_function.Rd" messages so
     # I figured capturing the output would be 'safer' than using sink and
     # diverting things. Oh well.
-    output <- capture.output(suppressWarnings(suppressMessages(roxygenize(package_dir, "rd"))))
+    output <- capture.output(suppressWarnings(suppressMessages(roxygenize(package_dir, "rd", load = "source"))))
 
 
     generated_Rd_file <- file.path(package_dir, "man", paste0(fun_name, ".Rd"))


### PR DESCRIPTION
Fixes #28 

Since `{roxygen2}` 7.0.0 (released 2019/11/12) `roxygenise` uses `pkgload::load_all()` by default. This ends up loading up the `devtools_shims` namespace - which includes its own version of the `?` function. 

This means that when you load up `{docstring}` you can use docstring's version of `?` but, behind the scenes, it runs `roxygenise()` which then loads up the `devtools_shims` namespace. Next time you use `?` you're running the one loaded up in `devtools_shims`. This is the source of the error found.

Adding the `load = "source"` argument in the `roxygenise()` call bypasses loading up the `devtools_shims` namespace but still produces the desired behaviour.